### PR TITLE
feat: re-format to have less waitgroup calls

### DIFF
--- a/ex-2-channels-routines/solution/main.go
+++ b/ex-2-channels-routines/solution/main.go
@@ -6,41 +6,48 @@ import (
 	"sync"
 )
 
-func queueMessage(ch chan string, msg string, wg *sync.WaitGroup) {
-	wg.Add(1)
+func queueMessage(ch chan string, msg string) {
 	ch <- msg
 }
 
 // TODO: clean up main
 func main() {
 	numWorkers := flag.Int("workers", 1, "number of workers")
-
 	flag.Parse()
-	wg := new(sync.WaitGroup)
 
+	wg := new(sync.WaitGroup)
 	ch := make(chan string, 10)
 
-	// make this a loop and randomize the words
-	queueMessage(ch, "Hello", wg)
-	queueMessage(ch, "World", wg)
-	queueMessage(ch, "!", wg)
-	queueMessage(ch, "I'm", wg)
-	queueMessage(ch, "a", wg)
-	queueMessage(ch, "worker", wg)
-	queueMessage(ch, "!", wg)
-	queueMessage(ch, "I'm", wg)
-	queueMessage(ch, "a", wg)
-	queueMessage(ch, "coder", wg)
-
+	// start the workers in the background and wait for data on the channel
+	// we already know the number of workers, we can increase the WaitGroup once
+	wg.Add(*numWorkers)
 	for i := 0; i < *numWorkers; i++ {
 		go worker(i, ch, wg)
 	}
+
+	// make this a loop and randomize the words
+	queueMessage(ch, "Hello")
+	queueMessage(ch, "World")
+	queueMessage(ch, "!")
+	queueMessage(ch, "I'm")
+	queueMessage(ch, "a")
+	queueMessage(ch, "worker")
+	queueMessage(ch, "!")
+	queueMessage(ch, "I'm")
+	queueMessage(ch, "a")
+	queueMessage(ch, "coder")
+
+	// close the worker channel and signal there won't be any more data
+	close(ch)
+
+	// wait for the workers to stop processing and exit
 	wg.Wait()
 }
 
 func worker(id int, ch chan string, wg *sync.WaitGroup) {
+	defer wg.Done()
+
 	for msg := range ch {
 		fmt.Printf("Worker %d received %s\n", id, msg)
-		wg.Done()
 	}
 }


### PR DESCRIPTION
Hi,
Less WaitGroup calls are better in terms of performance also it usually relates to the workes more than the jobs.

In this solution, the wg is only used to track the running workers and we can use the channel to stop all the workers and do a graceful shutdown when the channel is fully processed.

(I would probably even get rid of the `queueMessage` and use the `ch <- msg` directly.)