### PR TITLE
change ordering and drop the buffer from the channel

### DIFF
--- a/ex-2-channels-routines/solution/main.go
+++ b/ex-2-channels-routines/solution/main.go
@@ -12,8 +12,6 @@ func runWorkerPool(ch chan string, wg *sync.WaitGroup, numWorkers int) {
 	for i := 0; i < numWorkers; i++ {
 		go worker(i, ch, wg)
 	}
-	// wait for the workers to stop processing and exit
-	wg.Wait()
 }
 
 // TODO: clean up main
@@ -22,14 +20,17 @@ func main() {
 	flag.Parse()
 
 	wg := new(sync.WaitGroup)
-	ch := make(chan string, 10)
+	ch := make(chan string)
 
 	// start the workers in the background and wait for data on the channel
 	// we already know the number of workers, we can increase the WaitGroup once
 	wg.Add(*numWorkers)
 
-	queueMessages(ch)
 	runWorkerPool(ch, wg, *numWorkers)
+	queueMessages(ch)
+
+	// wait for the workers to stop processing and exit
+	wg.Wait()
 }
 
 // getMessages gets a slice of messages to process


### PR DESCRIPTION
One more, if you start the pool before sending messages there won't be any deadlocks and you can go with unbuffered channels too.
(Just need to wait for the workers after everything is done.)

I'd also move the `wg.Add(*numWorkers)` inside the `runWorkerPool` to keep it close to the actual goroutine starts.