### PR TITLE
fix golangci-lint config files

### DIFF
--- a/ex-1-local-env/.golangci.yml
+++ b/ex-1-local-env/.golangci.yml
@@ -1,10 +1,8 @@
 run:
-  timeout: 5m
-  issues-exit-code: 2
   tests: false
   modules-download-mode: readonly
-  go: '1.18' 
-  linters:
+linters:
+  disable-all: true
   enable:
     - bodyclose
     - deadcode
@@ -12,6 +10,8 @@ run:
     - errcheck
     - goconst
     - gocyclo
+    - godot
+    - godox
     - gofmt
     - gosimple
     - govet

--- a/ex-1-local-env/README.md
+++ b/ex-1-local-env/README.md
@@ -8,9 +8,9 @@ Visit the [golangci-lint](https://golangci-lint.run/usage/install/) site and ins
 
 ## Select Linters you want
 
-There many linters included as part of the Golangci-lint binary. The list of linters and description of what the linters check. Some linters overlap in functionality. Go thorugh the list and select some linters you want to apply. Use the command-line flags to run these against the `main.go` in the exercise . Here is an example of the command:
+There many linters included as part of the `golangci-lint` binary. The list of linters and description of what the linters check. Some linters overlap in functionality. Go thorugh the list and select some linters you want to apply. Use the command-line flags to run these against the `main.go` in the exercise. Here is an example of the command:
 ```bash
-golangci-lint run --enable deadcode errcheck govet
+golangci-lint run --no-config --disable-all --enable deadcode,errcheck,govet
 ```
 ## Add to IDE
 
@@ -27,5 +27,5 @@ Below are examples of my personal linting configurations.
 [link to dotfiles](https://github.com/Soypete/dotfiles/blob/main/vim/vimrc)
 
 ### Additional exercise: 
-You can create a `golangci-lint.yml` to store the configurations of our linters. An example file can be found [here](ex-1-local-env/.golangci-lint.yml). Additional configurations can also be found in [this file](https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml). And a `golangci-lint.yml` file to any local go repo you have and run the `golangci-lint run` command. Change the linter configs and try again.
+You can create a `.golangci.yml` to store the configurations of your linters. An example file can be found [here](.golangci.yml). Additional configurations can also be found in [this file](https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml). Add a `.golangci.yml` file to any local go repo you have and run the `golangci-lint run` command. Change the linter configs and try again.
 

--- a/ex-2-channels-routines/solution/.golangci.yml
+++ b/ex-2-channels-routines/solution/.golangci.yml
@@ -1,10 +1,8 @@
 run:
-  timeout: 5m
-  issues-exit-code: 2
   tests: false
   modules-download-mode: readonly
-  go: '1.17' 
-  linters:
+linters:
+  disable-all: true
   enable:
     - bodyclose
     - deadcode
@@ -12,6 +10,8 @@ run:
     - errcheck
     - goconst
     - gocyclo
+    - godot
+    - godox
     - gofmt
     - gosimple
     - govet


### PR DESCRIPTION
Hi.

I had to rename and edit the golang-ci-lint config files in ex-1-local-env and ex-2-channels-routines/solution.

I use golangci-lint version 1.50.1.

According to https://golangci-lint.run/usage/configuration/ the config files should be named .golangci.yml.
Also I removed some run options in the config files because I think the defaults are fine here.
More important I fixed the indentation for linters:.

I had to edit the ex-1-local-env/README.md as well:
    - I changed name of the config file, links, and typos.
    - More important the shell command to run individual linters did not work for me so I changed it.

BTW the Vim image and the dotfile vimrc has a typo: should be ineffassign not ifeffassign.

Best regards,
Kai-Uwe